### PR TITLE
Update to ZIO-2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 target
 .sbtopts
 project/.sbt
-
+.idea

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,6 @@ val scala212Opts = Seq(
   "-Xlint:delayedinit-select",         // Selecting member of DelayedInit.
   "-Xlint:doc-detached",               // A Scaladoc comment appears to be detached from its element.
   "-Xlint:inaccessible",               // Warn about inaccessible types in method signatures.
-  "-Xlint:infer-any",                  // Warn when a type argument is inferred to be `Any`.
   "-Xlint:missing-interpolator",       // A string literal appears to be missing an interpolator id.
   "-Xlint:nullary-unit",               // Warn when nullary methods return Unit.
   "-Xlint:option-implicit",            // Option.apply used implicit view.
@@ -43,7 +42,6 @@ val scala212Opts = Seq(
   "-Ywarn-dead-code",                  // Warn when dead code is identified.
   "-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
   "-Ywarn-inaccessible",               // Warn about inaccessible types in method signatures.
-  "-Ywarn-infer-any",                  // Warn when a type argument is inferred to be `Any`.
   "-Ywarn-nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
   "-Ywarn-nullary-unit",               // Warn when nullary methods return Unit.
   "-Ywarn-numeric-widen",              // Warn when numerics are widened.
@@ -73,7 +71,6 @@ val scala213Opts = Seq(
   "-Xlint:delayedinit-select", // Selecting member of DelayedInit.
   "-Xlint:doc-detached", // A Scaladoc comment appears to be detached from its element.
   "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
-  "-Xlint:infer-any", // Warn when a type argument is inferred to be `Any`.
   "-Xlint:missing-interpolator", // A string literal appears to be missing an interpolator id.
   "-Xlint:nullary-unit", // Warn when nullary methods return Unit.
   "-Xlint:option-implicit", // Option.apply used implicit view.
@@ -134,7 +131,7 @@ libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.30"
 resolvers +=
   "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 
-val zioVersion = "1.0.0"
+val zioVersion = "2.0.0"
 libraryDependencies += "dev.zio" %% "zio" % zioVersion
 libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3" % Test
 libraryDependencies += "com.storm-enroute" %% "scalameter" % "0.19" % Test

--- a/src/main/scala/com/github/mlangc/slf4zio/api/LogSpec.scala
+++ b/src/main/scala/com/github/mlangc/slf4zio/api/LogSpec.scala
@@ -1,6 +1,7 @@
 package com.github.mlangc.slf4zio.api
 
-import zio.{Cause, Duration}
+import zio.Cause
+import zio.Duration
 import zio.duration2DurationOps
 
 case class LogSpec[-E, -A](onError: List[(Duration, E) => LogMessage] = Nil,

--- a/src/main/scala/com/github/mlangc/slf4zio/api/LogSpec.scala
+++ b/src/main/scala/com/github/mlangc/slf4zio/api/LogSpec.scala
@@ -1,8 +1,7 @@
 package com.github.mlangc.slf4zio.api
 
-import zio.Cause
-import zio.duration.Duration
-import zio.duration.DurationOps
+import zio.{Cause, Duration}
+import zio.duration2DurationOps
 
 case class LogSpec[-E, -A](onError: List[(Duration, E) => LogMessage] = Nil,
                            onSucceed: List[(Duration, A) => LogMessage] = Nil,

--- a/src/main/scala/com/github/mlangc/slf4zio/api/LoggingSupport.scala
+++ b/src/main/scala/com/github/mlangc/slf4zio/api/LoggingSupport.scala
@@ -1,10 +1,8 @@
 package com.github.mlangc.slf4zio.api
 
-import com.github.ghik.silencer.silent
 import org.slf4j.Logger
 import zio.ZIO
 
-@silent("inferred to be `Any`")
 trait LoggingSupport { outer =>
   @transient
   protected final lazy val logger: Logger = getLogger(getClass)

--- a/src/main/scala/com/github/mlangc/slf4zio/api/LoggingSupport.scala
+++ b/src/main/scala/com/github/mlangc/slf4zio/api/LoggingSupport.scala
@@ -3,7 +3,6 @@ package com.github.mlangc.slf4zio.api
 import com.github.ghik.silencer.silent
 import org.slf4j.Logger
 import zio.ZIO
-import zio.clock.Clock
 
 @silent("inferred to be `Any`")
 trait LoggingSupport { outer =>
@@ -12,10 +11,10 @@ trait LoggingSupport { outer =>
 
   protected implicit final class ZioLoggerOps[R, E, A](zio: ZIO[R, E, A]) {
     def perfLog[E1 >: E](spec: LogSpec[E1, A]): ZIO[R, E, A] =
-      ZIO.accessM[R] { r =>
-        val io = zio.provide(r)
+      ZIO.environmentWithZIO[R] { r =>
+        val io = zio.provideEnvironment(r)
         io.perfLogZ(spec)
-          .provideLayer(Logging.forLogger(logger) ++ Clock.live)
+          .provideLayer(Logging.forLogger(logger))
       }
   }
 

--- a/src/main/scala/com/github/mlangc/slf4zio/api/MDZIO.scala
+++ b/src/main/scala/com/github/mlangc/slf4zio/api/MDZIO.scala
@@ -19,25 +19,25 @@ import zio.ZIO
 @silent("JavaConverters")
 abstract class MDZIO {
   final def put(key: String, value: String): UIO[Unit] =
-    UIO(MDC.put(key, value))
+    ZIO.succeed(MDC.put(key, value))
 
   final def get(key: String): UIO[Option[String]] =
-    UIO(Option(MDC.get(key)))
+    ZIO.succeed(Option(MDC.get(key)))
 
   final def remove(key: String): UIO[Unit] =
-    UIO(MDC.remove(key))
+    ZIO.succeed(MDC.remove(key))
 
   final def clear(): UIO[Unit] =
-    UIO(MDC.clear())
+    ZIO.succeed(MDC.clear())
 
   final def putAll(pairs: (String, String)*): UIO[Unit] =
     putAll(pairs)
 
   final def putAll(pairs: Iterable[(String, String)]): UIO[Unit] =
-    ZIO.foreach_(pairs)((put _).tupled)
+    ZIO.foreachDiscard(pairs)((put _).tupled)
 
   final def removeAll(keys: Iterable[String]): UIO[Unit] =
-    ZIO.foreach_(keys)(remove)
+    ZIO.foreachDiscard(keys)(remove)
 
   /**
    * Puts the given key value pairs in the context, executes the given action, and restores the original context.
@@ -55,10 +55,10 @@ abstract class MDZIO {
     doWith(pairs)(zio)
 
   final def getContextMap: UIO[Option[Map[String, String]]] =
-    UIO(Option(MDC.getCopyOfContextMap).map(_.asScala.toMap))
+    ZIO.succeed(Option(MDC.getCopyOfContextMap).map(_.asScala.toMap))
 
   final def setContextMap(map: Map[String, String]): UIO[Unit] =
-    UIO(MDC.setContextMap(map.asJava))
+    ZIO.succeed(MDC.setContextMap(map.asJava))
 
   private def getAll(keys: Iterable[String]): UIO[Map[String, String]] =
     ZIO.foldLeft(keys)(Map.empty[String, String]) { (acc, key) =>

--- a/src/main/scala/com/github/mlangc/slf4zio/api/package.scala
+++ b/src/main/scala/com/github/mlangc/slf4zio/api/package.scala
@@ -1,11 +1,23 @@
 package com.github.mlangc.slf4zio
 
-import org.slf4j.{Logger, LoggerFactory, Marker, MarkerFactory}
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.slf4j.Marker
+import org.slf4j.MarkerFactory
 import org.slf4j.event.Level
-import zio.{Cause, Clock, Duration, UIO, ULayer, URIO, ZIO, ZLayer}
+import zio.Cause
+import zio.Clock
+import zio.Duration
+import zio.UIO
+import zio.ULayer
+import zio.URIO
+import zio.ZIO
+import zio.ZLayer
 
 import scala.reflect.ClassTag
-import scala.util.{Failure, Success, Try}
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
 
 package object api {
   implicit final class Slf4jLoggerOps(logger: => Logger) {

--- a/src/main/scala/com/github/mlangc/slf4zio/api/package.scala
+++ b/src/main/scala/com/github/mlangc/slf4zio/api/package.scala
@@ -1,130 +1,116 @@
 package com.github.mlangc.slf4zio
 
-import scala.reflect.ClassTag
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
-
+import org.slf4j.{Logger, LoggerFactory, Marker, MarkerFactory}
 import org.slf4j.event.Level
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
-import org.slf4j.Marker
-import org.slf4j.MarkerFactory
-import zio.Cause
-import zio.Has
-import zio.UIO
-import zio.ULayer
-import zio.URIO
-import zio.ZIO
-import zio.ZLayer
-import zio.clock
-import zio.clock.Clock
-import zio.duration.Duration
+import zio.{Cause, Clock, Duration, UIO, ULayer, URIO, ZIO, ZLayer}
+
+import scala.reflect.ClassTag
+import scala.util.{Failure, Success, Try}
 
 package object api {
   implicit final class Slf4jLoggerOps(logger: => Logger) {
-    def traceIO(msg: => String): UIO[Unit] = UIO {
+    def traceIO(msg: => String): UIO[Unit] = ZIO.succeed {
       if (logger.isTraceEnabled())
         logger.trace(msg)
     }
 
-    def debugIO(msg: => String): UIO[Unit] = UIO {
+    def debugIO(msg: => String): UIO[Unit] = ZIO.succeed {
       if (logger.isDebugEnabled)
         logger.debug(msg)
     }
 
-    def infoIO(msg: => String): UIO[Unit] = UIO {
+    def infoIO(msg: => String): UIO[Unit] = ZIO.succeed {
       if (logger.isInfoEnabled())
         logger.info(msg)
     }
 
-    def warnIO(msg: => String): UIO[Unit] = UIO {
+    def warnIO(msg: => String): UIO[Unit] = ZIO.succeed {
       if (logger.isWarnEnabled())
         logger.warn(msg)
     }
 
-    def errorIO(msg: => String): UIO[Unit] = UIO {
+    def errorIO(msg: => String): UIO[Unit] = ZIO.succeed {
       if (logger.isErrorEnabled())
         logger.error(msg)
     }
 
-    def traceIO(msg: => String, th: Throwable): UIO[Unit] = UIO {
+    def traceIO(msg: => String, th: Throwable): UIO[Unit] = ZIO.succeed {
       if (logger.isTraceEnabled())
         logger.trace(msg, th)
     }
 
-    def debugIO(msg: => String, th: Throwable): UIO[Unit] = UIO {
+    def debugIO(msg: => String, th: Throwable): UIO[Unit] = ZIO.succeed {
       if (logger.isDebugEnabled)
         logger.debug(msg, th)
     }
 
-    def infoIO(msg: => String, th: Throwable): UIO[Unit] = UIO {
+    def infoIO(msg: => String, th: Throwable): UIO[Unit] = ZIO.succeed {
       if (logger.isInfoEnabled)
         logger.info(msg, th)
     }
 
-    def warnIO(msg: => String, th: Throwable): UIO[Unit] = UIO {
+    def warnIO(msg: => String, th: Throwable): UIO[Unit] = ZIO.succeed {
       if (logger.isWarnEnabled)
         logger.warn(msg, th)
     }
 
-    def errorIO(msg: => String, th: Throwable): UIO[Unit] = UIO {
+    def errorIO(msg: => String, th: Throwable): UIO[Unit] = ZIO.succeed {
       if (logger.isErrorEnabled)
         logger.error(msg, th)
     }
 
-    def traceIO(marker: Marker, msg: => String): UIO[Unit] = UIO {
+    def traceIO(marker: Marker, msg: => String): UIO[Unit] = ZIO.succeed {
       if (logger.isTraceEnabled(marker))
         logger.trace(marker, msg)
     }
 
-    def debugIO(marker: Marker, msg: => String): UIO[Unit] = UIO {
+    def debugIO(marker: Marker, msg: => String): UIO[Unit] = ZIO.succeed {
       if (logger.isDebugEnabled(marker))
         logger.debug(marker, msg)
     }
 
-    def infoIO(marker: Marker, msg: => String): UIO[Unit] = UIO {
+    def infoIO(marker: Marker, msg: => String): UIO[Unit] = ZIO.succeed {
       if (logger.isInfoEnabled(marker))
         logger.info(marker, msg)
     }
 
-    def warnIO(marker: Marker, msg: => String): UIO[Unit] = UIO {
+    def warnIO(marker: Marker, msg: => String): UIO[Unit] = ZIO.succeed {
       if (logger.isWarnEnabled(marker))
         logger.warn(marker, msg)
     }
 
-    def errorIO(marker: Marker, msg: => String): UIO[Unit] = UIO {
+    def errorIO(marker: Marker, msg: => String): UIO[Unit] = ZIO.succeed {
       if (logger.isErrorEnabled(marker))
         logger.error(marker, msg)
     }
 
-    def traceIO(marker: Marker, msg: => String, th: Throwable): UIO[Unit] = UIO {
+    def traceIO(marker: Marker, msg: => String, th: Throwable): UIO[Unit] = ZIO.succeed {
       if (logger.isTraceEnabled(marker))
         logger.trace(marker, msg, th)
     }
 
-    def debugIO(marker: Marker, msg: => String, th: Throwable): UIO[Unit] = UIO {
+    def debugIO(marker: Marker, msg: => String, th: Throwable): UIO[Unit] = ZIO.succeed {
       if (logger.isDebugEnabled)
         logger.debug(marker, msg, th)
     }
 
-    def infoIO(marker: Marker, msg: => String, th: Throwable): UIO[Unit] = UIO {
+    def infoIO(marker: Marker, msg: => String, th: Throwable): UIO[Unit] = ZIO.succeed {
       if (logger.isInfoEnabled)
         logger.info(marker, msg, th)
     }
 
-    def warnIO(marker: Marker, msg: => String, th: Throwable): UIO[Unit] = UIO {
+    def warnIO(marker: Marker, msg: => String, th: Throwable): UIO[Unit] = ZIO.succeed {
       if (logger.isWarnEnabled)
         logger.warn(marker, msg, th)
     }
 
-    def errorIO(marker: Marker, msg: => String, th: Throwable): UIO[Unit] = UIO {
+    def errorIO(marker: Marker, msg: => String, th: Throwable): UIO[Unit] = ZIO.succeed {
       if (logger.isErrorEnabled)
         logger.error(marker, msg, th)
     }
 
     def logIO(msg: LogMessage): UIO[Unit] =
-      UIO(log(msg))
+      ZIO.succeed(log(msg))
 
     def log(msg: LogMessage): Unit =
       if (msg.suppressed) () else msg.level match {
@@ -135,11 +121,11 @@ package object api {
         case Level.TRACE => logger.trace(msg.text)
       }
 
-    def perfLogZIO[R, E, A, E2 >: E, A2 >: A](zio: ZIO[R, E, A])(spec: LogSpec[E2, A2]): ZIO[R with Clock, E, A] =
-      if (spec.isNoOp) zio else clock.nanoTime.flatMap { t0 =>
-        def handleError(cause: Cause[E]): ZIO[Clock, E, Nothing] =
-          if (spec.onError.isEmpty && spec.onTermination.isEmpty) ZIO.halt(cause)
-          else clock.nanoTime.flatMap { t1 =>
+    def perfLogZIO[R, E, A, E2 >: E, A2 >: A](zio: ZIO[R, E, A])(spec: LogSpec[E2, A2]): ZIO[R, E, A] =
+      if (spec.isNoOp) zio else Clock.nanoTime.flatMap { t0 =>
+        def handleError(cause: Cause[E]): ZIO[Any, E, Nothing] =
+          if (spec.onError.isEmpty && spec.onTermination.isEmpty) ZIO.failCause(cause)
+          else Clock.nanoTime.flatMap { t1 =>
             val d = Duration.fromNanos(t1 - t0)
 
             val msgs = cause.failureOrCause match {
@@ -147,26 +133,26 @@ package object api {
               case Left(e) => spec.onError.map(_ (d, e))
             }
 
-            ZIO.foreach(msgs)(m => logger.logIO(m)) *> ZIO.halt(cause)
+            ZIO.foreach(msgs)(m => logger.logIO(m)) *> ZIO.failCause(cause)
           }
 
-        def handleSuccess(a: A): ZIO[Clock, Nothing, A] =
+        def handleSuccess(a: A): ZIO[Any, Nothing, A] =
           if (spec.onSucceed.isEmpty) ZIO.succeed(a) else {
             for {
-              t1 <- clock.nanoTime
+              t1 <- Clock.nanoTime
               d = Duration.fromNanos(t1 - t0)
               msgs = spec.onSucceed.map(_ (d, a))
               _ <- ZIO.foreach(msgs)(m => logger.logIO(m))
             } yield a
           }
 
-        zio.foldCauseM(handleError, handleSuccess)
+        zio.foldCauseZIO(handleError, handleSuccess)
       }
 
     def perfLogIO[R, E, A](zio: ZIO[R, E, A])(spec: LogSpec[E, A]): ZIO[R, E, A] =
-      ZIO.accessM[R] { r =>
-        val io = zio.provide(r)
-        perfLogZIO(io)(spec).provideLayer(Clock.live)
+      ZIO.environmentWithZIO[R] { r =>
+        val io = zio.provideEnvironment(r)
+        perfLogZIO(io)(spec).provideLayer(ZLayer.succeed(Clock.ClockLive))
       }
 
     def perfLog[A](thunk: => A)(spec: LogSpec[Throwable, A]): A =
@@ -269,35 +255,35 @@ package object api {
       def logger: URIO[R, Logger]
 
       private def withUnderlying(op: Logger => UIO[Unit]): URIO[R, Unit] =
-        logger >>= op
+        logger.flatMap(op)
     }
 
     def forClass(clazz: Class[_]): ULayer[Logging] = ZLayer.succeed {
-      new Service[Any] with Serializable {
+      new Service[Any] {
         @transient
         private lazy val theLogger = getLogger(clazz)
 
-        def logger: UIO[Logger] = UIO(theLogger)
+        def logger: UIO[Logger] = ZIO.succeed(theLogger)
       }
     }
 
     def forLogger(getLogger: => Logger): ULayer[Logging] = ZLayer.succeed {
-      new Service[Any] with Serializable {
-        def logger: UIO[Logger] = UIO(getLogger)
+      new Service[Any] {
+        def logger: UIO[Logger] = ZIO.succeed(getLogger)
       }
     }
 
     def global: ULayer[Logging] = forClass(Logging.getClass)
 
     val any: ZLayer[Logging, Nothing, Logging] =
-      ZLayer.requires[Logging]
+      ZLayer.environment[Logging]
   }
 
-  type Logging = Has[Logging.Service[Any]]
+  type Logging = Logging.Service[Any]
 
   val logging: Logging.Service[Logging] = new Logging.Service[Logging] {
     def logger: URIO[Logging, Logger] =
-      ZIO.accessM[Logging](_.get[Logging.Service[Any]].logger)
+      ZIO.environmentWithZIO[Logging](_.get[Logging.Service[Any]].logger)
   }
 
   def getLogger[T](implicit classTag: ClassTag[T]): Logger =
@@ -310,16 +296,16 @@ package object api {
     LoggerFactory.getLogger(name)
 
   def getMarker(name: String): UIO[Marker] =
-    UIO(MarkerFactory.getMarker(name))
+    ZIO.succeed(MarkerFactory.getMarker(name))
 
   def makeLogger(name: String): UIO[Logger] =
-    UIO(getLogger(name))
+    ZIO.succeed(getLogger(name))
 
   def makeLogger[T](implicit classTag: ClassTag[T]): UIO[Logger] =
-    UIO(getLogger[T])
+    ZIO.succeed(getLogger[T])
 
   def makeLogger[T](clazz: Class[_]): UIO[Logger] =
-    UIO(getLogger(clazz))
+    ZIO.succeed(getLogger(clazz))
 
   implicit final class LogMessageInterpolator(val stringContext: StringContext) extends AnyVal {
     def trace(args: Any*): LogMessage = {
@@ -344,8 +330,8 @@ package object api {
   }
 
   implicit final class ZioLoggingOps[R, E, A](val zio: ZIO[R, E, A]) {
-    def perfLogZ[E2 >: E, A2 >: A](spec: LogSpec[E2, A2]): ZIO[R with Logging with Clock, E, A] =
-      ZIO.accessM[Logging](_.get[Logging.Service[Any]].logger)
+    def perfLogZ[E2 >: E, A2 >: A](spec: LogSpec[E2, A2]): ZIO[R with Logging, E, A] =
+      ZIO.environmentWithZIO[Logging](_.get[Logging.Service[Any]].logger)
         .flatMap(_.perfLogZIO(zio)(spec))
   }
 }

--- a/src/test/scala/com/github/mlangc/slf4zio/LogbackInitializationTimeout.scala
+++ b/src/test/scala/com/github/mlangc/slf4zio/LogbackInitializationTimeout.scala
@@ -1,6 +1,6 @@
 package com.github.mlangc.slf4zio
 
-import zio.duration.Duration
-import zio.duration.DurationOps
+import zio.Duration
+import zio.duration2DurationOps
 
 case class LogbackInitializationTimeout(elapsed: Duration) extends RuntimeException(s"Logback initialization timed out after ${elapsed.render}")

--- a/src/test/scala/com/github/mlangc/slf4zio/LogbackTestAppender.scala
+++ b/src/test/scala/com/github/mlangc/slf4zio/LogbackTestAppender.scala
@@ -2,10 +2,9 @@ package com.github.mlangc.slf4zio
 
 import java.util.concurrent.atomic.AtomicReference
 import java.util.function.UnaryOperator
-
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.AppenderBase
-import zio.UIO
+import zio.{UIO, ZIO}
 
 class LogbackTestAppender extends AppenderBase[ILoggingEvent] {
   def append(eventObject: ILoggingEvent): Unit = {
@@ -21,7 +20,7 @@ object LogbackTestAppender {
   private val eventsRef = new AtomicReference(List.empty[ILoggingEvent])
 
   def events: UIO[List[ILoggingEvent]] =
-    UIO(eventsRef.get())
+    ZIO.succeed(eventsRef.get())
 
   def eventsFor(clazz: Class[_]): UIO[List[ILoggingEvent]] =
     events.map(_.filter(_.getLoggerName == clazz.getCanonicalName))

--- a/src/test/scala/com/github/mlangc/slf4zio/LogbackTestAppender.scala
+++ b/src/test/scala/com/github/mlangc/slf4zio/LogbackTestAppender.scala
@@ -4,7 +4,8 @@ import java.util.concurrent.atomic.AtomicReference
 import java.util.function.UnaryOperator
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.AppenderBase
-import zio.{UIO, ZIO}
+import zio.UIO
+import zio.ZIO
 
 class LogbackTestAppender extends AppenderBase[ILoggingEvent] {
   def append(eventObject: ILoggingEvent): Unit = {

--- a/src/test/scala/com/github/mlangc/slf4zio/LogbackTestUtils.scala
+++ b/src/test/scala/com/github/mlangc/slf4zio/LogbackTestUtils.scala
@@ -2,26 +2,20 @@ package com.github.mlangc.slf4zio
 
 import ch.qos.logback.classic.LoggerContext
 import org.slf4j.LoggerFactory
-import zio.IO
-import zio.Schedule
-import zio.UIO
-import zio.ZIO
-import zio.clock.Clock
-import zio.duration.Duration
-import zio.duration.durationInt
+import zio.{Duration, IO, Schedule, UIO, ZIO, durationInt}
 
 object LogbackTestUtils {
   def waitForLogbackInitialization: IO[LogbackInitializationTimeout, Unit] = {
-    val schedule: Schedule[Clock, Boolean, (Boolean, Duration)] =
+    val schedule: Schedule[Any, Boolean, (Boolean, Duration)] =
       (Schedule.recurUntil[Boolean](identity) <* (Schedule.spaced(1.milli) <* Schedule.recurs(500))) && Schedule.elapsed
 
     logbackInitialized.repeat(schedule).flatMap {
       case (true, _) => ZIO.unit
       case (false, elapsed) => ZIO.fail(LogbackInitializationTimeout(elapsed))
-    }.provideLayer(Clock.live)
+    }
   }
 
-  def logbackInitialized: UIO[Boolean] = UIO {
+  def logbackInitialized: UIO[Boolean] = ZIO.succeed {
     LoggerFactory.getILoggerFactory.isInstanceOf[LoggerContext]
   }
 }

--- a/src/test/scala/com/github/mlangc/slf4zio/api/MDZIOTest.scala
+++ b/src/test/scala/com/github/mlangc/slf4zio/api/MDZIOTest.scala
@@ -3,12 +3,12 @@ package com.github.mlangc.slf4zio.api
 import zio.ZIO
 import zio.test.Assertion.equalTo
 import zio.test.Assertion.isNone
-import zio.test.DefaultRunnableSpec
 import zio.test._
+import zio.test.ZIOSpecDefault
 
-object MDZIOTest extends DefaultRunnableSpec {
+object MDZIOTest extends ZIOSpecDefault {
   def spec = suite("MDZIO")(
-    testM("put, get & clear works properly") {
+    test("put, get & clear works properly") {
       val (x, y) = ("x", "y")
       val (a, b) = ("a", "b")
 
@@ -21,7 +21,7 @@ object MDZIOTest extends DefaultRunnableSpec {
         v4 <- MDZIO.get(y)
       } yield assert((v1, v2, v3, v4))(equalTo((Some(a), Some(b), None, None)))
     },
-    testM("doWith") {
+    test("doWith") {
       val (d, e, f, g) = ("d", "e", "f", "g")
       val (k, l, m, n) = ("k", "l", "m", "n")
       val m0 = "m0"
@@ -35,7 +35,7 @@ object MDZIOTest extends DefaultRunnableSpec {
         v2 <- ZIO.foreach(defg)(MDZIO.get)
       } yield assert(v1.flatten)(equalTo(klmn)) && assert(v2.flatten)(equalTo(km0))
     },
-    testM("setContextMap") {
+    test("setContextMap") {
       val (r, s) = ("r", "s")
 
       for {

--- a/src/test/scala/com/github/mlangc/slf4zio/api/RawPerfLogTest.scala
+++ b/src/test/scala/com/github/mlangc/slf4zio/api/RawPerfLogTest.scala
@@ -1,8 +1,11 @@
 package com.github.mlangc.slf4zio.api
 
-import com.github.mlangc.slf4zio.{LogbackTestAppender, LogbackTestUtils}
-import zio.test.{ZIOSpecDefault, _}
-import zio.{ZIO, duration2DurationOps, durationInt}
+import com.github.mlangc.slf4zio.LogbackTestAppender
+import com.github.mlangc.slf4zio.LogbackTestUtils
+import zio.test._
+import zio.ZIO
+import zio.duration2DurationOps
+import zio.durationInt
 
 object RawPerfLogTest extends ZIOSpecDefault {
   def spec = suite("Raw Performance Log")(


### PR DESCRIPTION
Quick draft PR to update to ZIO-2.0.0. Changes to api usage mostly done by zio migration tool. Removed ZEnv from layer definitions, it's no longer explicitly required. UIO { ... }, etc. changed to ZIO.attempt or ZIO.succeed. 

"-Xlint:infer-any" removed due to causing spurious warning `a type was inferred to be Any;` with `val schedule: Schedule[Any, Boolean, (Boolean, Duration)] =
      (Schedule.recurUntil[Boolean](identity) <* (Schedule.spaced(1.milli) <* Schedule.recurs(500))) && Schedule.elapsed`

There probably should be a new branch to maintain ZIO-2.0.0 implementation.